### PR TITLE
Update fit pulls print functions plus minor correction

### DIFF
--- a/errorScaleCal/test/fitPulls.py
+++ b/errorScaleCal/test/fitPulls.py
@@ -1,14 +1,21 @@
 import numpy
 from argparse import ArgumentParser
-
+import os, sys
 parser = ArgumentParser()
 parser.add_argument("-i"  , "--input"     , dest = "input"     ,  help = "input file"       , default = ''                        )
 parser.add_argument("-d"  , "--diff"      , dest = "diff"      ,  help = "plot differences" , default = False, action='store_true')
 parser.add_argument("-l"  , "--leg"       , dest = "leg"       ,  help = "legend labels"    , default = ''                        )
+parser.add_argument("-o"  , "--out"       , dest = "out"       ,  help = "output directory" , default = 'pull_resolution_plots'   )
 
 options = parser.parse_args()
 if not options.input:   
   parser.error('Input filename not given')
+
+if not os.path.exists(options.out):
+  os.makedirs(options.out)
+else:
+  print("Directory {} already exists. Will not overwrite. Exit.".format(options.out))
+  sys.exit(0)
 
 import ROOT
 import math
@@ -146,5 +153,5 @@ for ix, var in product(wrt,variables):
 
   gPad.SetGridx(True)
   gPad.SetGridy(True)
-  nc.SaveAs( 'pull_resolution_plots/' + var[6] + 'vs' + ix[0] + '_2018A_selected.pdf')
+  nc.SaveAs( options.out + '/' + var[6] + 'vs' + ix[0] + '_2018A_selected.pdf')
 

--- a/errorScaleCal/test/fitPulls.py
+++ b/errorScaleCal/test/fitPulls.py
@@ -117,15 +117,15 @@ for ix, var in product(wrt,variables):
       else:
         thex   .append(float(i*10+5))
        
-    yvec      = numpy.array( they           )
-    yerrvec   = numpy.array( theyerr        )
-    xvec      = numpy.array( thex           )
+    yvec      = numpy.array( they           , dtype = numpy.float)
+    yerrvec   = numpy.array( theyerr        , dtype = numpy.float)
+    xvec      = numpy.array( thex           , dtype = numpy.float)
   
     if 'sumPt' not in ix[0]:
-      xerrvec   = numpy.array( [0.5 for i in yvec]     )
+      xerrvec   = numpy.array( [0.5 for i in yvec], dtype = numpy.float)
     else:
-      xerrvec   = numpy.array( [5 for i in yvec]     )
-  
+      xerrvec   = numpy.array( [5.0 for i in yvec], dtype = numpy.float)
+
     g = ROOT.TGraphErrors( len(yvec), xvec, yvec, xerrvec, yerrvec)
     nc.cd()
 

--- a/errorScaleCal/test/fitPulls.py
+++ b/errorScaleCal/test/fitPulls.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import numpy
 from argparse import ArgumentParser
 import os, sys
@@ -35,9 +37,9 @@ namefiles = options.input.split(',')
 nfiles   = len(namefiles)
 files    = []
 
-print 'number of input files is ' + str(nfiles)
+print ('number of input files is ' + str(nfiles))
 for i in range(0, nfiles):
-  print 'opening file ' + str(i) + ': ' + namefiles[i]
+  print ('opening file ' + str(i) + ': ' + namefiles[i])
   files.append(TFile.Open(namefiles[i]   , 'r') )
 
 
@@ -126,8 +128,8 @@ for ix, var in product(wrt,variables):
   
     g = ROOT.TGraphErrors( len(yvec), xvec, yvec, xerrvec, yerrvec)
     nc.cd()
-  
-    print colorlist[j]
+
+    print (colorlist[j])
     g.SetLineColor  (colorlist[j])
     g.SetMarkerColor(colorlist[j])
     g.SetMarkerStyle(8 )


### PR DESCRIPTION
This PR update the fitPulls.py to be used in python3. It also add an explicit type (float) to the numpy arrays to avoid crashed when converting to float* for TGraphs. It also adds an output option.